### PR TITLE
Add support for specifying publicPath in argv

### DIFF
--- a/bin/protonPack
+++ b/bin/protonPack
@@ -20,6 +20,10 @@ const {
     apiUrl
 } = configAppBuilder(argv);
 
+const {
+    publicPath = '/',
+    port: specifiedPort
+} = argv;
 
 async function main() {
 
@@ -31,16 +35,16 @@ async function main() {
     // Run the dev server, but first find an available port
     if (isDevServer) {
         const server = require('../cli/server');
-        const port = await findPort();
+        const port = specifiedPort || await findPort();
 
-        const log = (ip = 'localhost') => chalk.yellow(`http://${ip}:${port}`);
+        const log = (ip = 'localhost') => chalk.yellow(`http://${ip}:${port}${publicPath}`);
         console.log(dedent`
             ➙ Dev server: ${log()}
             ➙ Dev server: ${log(localIp())}
             ➙ API: ${chalk.yellow(apiUrl)}
             \n
         `);
-        const CONFIG = configBuilder({ port });
+        const CONFIG = configBuilder({ port, publicPath });
 
         const run = server(CONFIG);
         run.listen(port);

--- a/bin/protonPack
+++ b/bin/protonPack
@@ -9,7 +9,7 @@ const localIp = require('my-local-ip');
 
 const configBuilder = require('../cli/config');
 const configAppBuilder = require('../cli/configApp');
-const { getPort, findPort } = require('../webpack/helpers/source');
+const { getPort, getPublicPath, findPort } = require('../webpack/helpers/source');
 
 const isInit = argv._.includes('init');
 const isDevServer = argv._.includes('dev-server');
@@ -19,11 +19,6 @@ const {
     path: appConfigPath,
     apiUrl
 } = configAppBuilder(argv);
-
-const {
-    publicPath = '/',
-    port: specifiedPort
-} = argv;
 
 async function main() {
 
@@ -35,7 +30,8 @@ async function main() {
     // Run the dev server, but first find an available port
     if (isDevServer) {
         const server = require('../cli/server');
-        const port = specifiedPort || await findPort();
+        const port = await findPort(getPort(argv));
+        const publicPath = getPublicPath(argv);
 
         const log = (ip = 'localhost') => chalk.yellow(`http://${ip}:${port}${publicPath}`);
         console.log(dedent`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,13 +11,14 @@ const { outputPath } = require('./webpack/paths');
 const { excludeNodeModulesExcept, excludeFiles, createRegex } = require('./webpack/helpers/regex');
 const { BABEL_EXCLUDE_FILES, BABEL_INCLUDE_NODE_MODULES } = require('./webpack/constants');
 
-const conf = {
-    isProduction: process.env.NODE_ENV === 'production'
-};
+function main({ port, publicPath }) {
+    const conf = {
+        isProduction: process.env.NODE_ENV === 'production',
+        publicPath: publicPath || '/'
+    };
 
-const { isProduction } = conf;
+    const { isProduction } = conf;
 
-function main({ port }) {
     return {
         stats: 'minimal',
         mode: !isProduction ? 'development' : 'production',
@@ -36,9 +37,12 @@ function main({ port }) {
             compress: true,
             host: '0.0.0.0',
             public: 'localhost',
-            historyApiFallback: true,
+            historyApiFallback: {
+                index: publicPath
+            },
             disableHostCheck: true,
             contentBase: outputPath,
+            publicPath,
             stats: 'minimal'
         },
         resolve: {
@@ -62,6 +66,7 @@ function main({ port }) {
         output: {
             path: outputPath,
             filename: isProduction ? '[name].[chunkhash:8].js' : '[name].js',
+            publicPath,
             chunkFilename: isProduction ? '[name].[chunkhash:8].chunk.js' : '[name].chunk.js',
             crossOriginLoading: 'anonymous'
         },

--- a/webpack/helpers/openpgp.js
+++ b/webpack/helpers/openpgp.js
@@ -2,14 +2,19 @@ const path = require('path');
 
 const transformFile = require('./files');
 
-const getDefineObject = ({ filepath, integrity }) => ({ filepath, integrity });
+const getDefineObject = (publicPath, { filepath, integrity }) => {
+    return {
+        filepath: path.join(publicPath, filepath),
+        integrity
+    };
+};
 
 const transformWorkerContents = (path, contents) =>
     contents.replace('self.window=self,importScripts("openpgp.min.js");', '');
 
 const transformCompatPath = ({ basename, ext, hash }) => [basename, 'compat', hash, ext].join('.');
 
-const transform = (openpgpPaths, openpgpWorkerPath, isDistRelease) => {
+const transform = (openpgpPaths, openpgpWorkerPath, publicPath, isDistRelease) => {
     const main = transformFile({
         filepath: path.resolve(openpgpPaths[0]),
         hash: isDistRelease
@@ -29,9 +34,9 @@ const transform = (openpgpPaths, openpgpWorkerPath, isDistRelease) => {
 
     const getDefinition = () => {
         return {
-            main: getDefineObject(main),
-            compat: getDefineObject(compat),
-            worker: getDefineObject(worker)
+            main: getDefineObject(publicPath, main),
+            compat: getDefineObject(publicPath, compat),
+            worker: getDefineObject(publicPath, worker)
         };
     };
 

--- a/webpack/helpers/source.js
+++ b/webpack/helpers/source.js
@@ -2,19 +2,23 @@ const path = require('path');
 const ROOT_DIR = process.cwd();
 const portfinder = require('portfinder'); // Coming from webpack-dev-server
 
-const getPort = () => process.env.NODE_ENV_PORT || 8080;
-const findPort = async () => {
+const getPort = ({ port }) => port || process.env.NODE_ENV_PORT || 8080;
+
+const findPort = async (basePort) => {
     // Default PORT for webpack
-    portfinder.basePort = getPort();
+    portfinder.basePort = basePort;
     const port = await portfinder.getPortPromise();
     process.env.NODE_ENV_PORT = port;
     return port;
 };
+
+const getPublicPath = ({ publicPath }) => publicPath || process.env.PUBLIC_PATH || '/';
 
 const getSource = (input) => path.join(ROOT_DIR, input);
 
 module.exports = {
     getPort,
     findPort,
-    getSource
+    getSource,
+    getPublicPath
 };

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -62,8 +62,13 @@ const PRODUCTION_PLUGINS = [
     })
 ];
 
-module.exports = ({ isProduction }) => {
-    const { main, worker, compat, definition } = transformOpenpgpFiles(OPENPGP_FILES, OPENPGP_WORKERS[0], isProduction);
+module.exports = ({ isProduction, publicPath }) => {
+    const { main, worker, compat, definition } = transformOpenpgpFiles(
+        OPENPGP_FILES,
+        OPENPGP_WORKERS[0],
+        publicPath,
+        isProduction
+    );
 
     return [
         new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
Add support for specifying a `publicPath` (and `port`) in argv.

Example:

```
npm run start -- --api=dev --publicPath=/settings/ --port=3010
```

Would build and serve locally the app starting from the /settings/ prefix
