### PR TITLE
Add another entry point for unsupported browsers

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,7 +87,8 @@ function main({ port, publicPath, flow, appMode }) {
             }
         },
         entry: {
-            index: [...SOURCES_DEV_SERVER, getSource('./src/app/index.js')]
+            index: [...SOURCES_DEV_SERVER, getSource('./src/app/index.js')],
+            unsupported: [getSource('./node_modules/proton-shared/lib/src/app/unsupported.js')]
         },
         output: {
             path: outputPath,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -87,8 +87,13 @@ function main({ port, publicPath, flow, appMode }) {
             }
         },
         entry: {
-            index: [...SOURCES_DEV_SERVER, getSource('./src/app/index.js')],
-            unsupported: [getSource('./node_modules/proton-shared/lib/src/app/unsupported.js')]
+            // The order is important. The supported.js file sets a global variable that is used by unsupported.js to detect if the main bundle could be parsed.
+            index: [
+                ...SOURCES_DEV_SERVER,
+                getSource('./src/app/index.js'),
+                getSource('./node_modules/proton-shared/lib/browser/supported.js')
+            ],
+            unsupported: [getSource('./node_modules/proton-shared/lib/browser/unsupported.js')]
         },
         output: {
             path: outputPath,

--- a/webpack/js.loader.js
+++ b/webpack/js.loader.js
@@ -41,7 +41,7 @@ module.exports = ({ isProduction }, flow) => {
                                 browsers: isProduction
                                     ? [
                                           // TODO: Only browsers that support es6
-                                          '> 0.5%, not IE 11'
+                                          '> 0.5%, not IE 11, Firefox ESR'
                                       ]
                                     : ['last 1 chrome version', 'last 1 firefox version', 'last 1 safari version']
                             },

--- a/webpack/js.loader.js
+++ b/webpack/js.loader.js
@@ -3,6 +3,28 @@ const { BABEL_EXCLUDE_FILES, BABEL_INCLUDE_NODE_MODULES } = require('./constants
 
 const BABEL_PLUGINS_PRODUCTION = [['babel-plugin-transform-react-remove-prop-types', { removeImport: true }]];
 
+const UNSUPPORTED_JS_LOADER = [
+    {
+        loader: 'babel-loader',
+        options: {
+            cacheDirectory: true,
+            cacheCompression: true,
+            compact: true,
+            presets: [
+                [
+                    '@babel/preset-env',
+                    {
+                        targets: { browsers: ['ie 11'] },
+                        useBuiltIns: 'entry',
+                        corejs: 3
+                    }
+                ]
+            ],
+            plugins: []
+        }
+    }
+];
+
 module.exports = ({ isProduction }, flow) => {
     const TRANSPILE_JS_LOADER = [
         {
@@ -77,10 +99,14 @@ module.exports = ({ isProduction }, flow) => {
             enforce: 'pre'
         },
         {
+            test: /unsupported\.js$/,
+            use: UNSUPPORTED_JS_LOADER
+        },
+        {
             test: /\.js$/,
             exclude: createRegex(
                 excludeNodeModulesExcept(BABEL_INCLUDE_NODE_MODULES),
-                excludeFiles(BABEL_EXCLUDE_FILES)
+                excludeFiles([...BABEL_EXCLUDE_FILES, 'unsupported.js'])
             ),
             use: TRANSPILE_JS_LOADER
         }

--- a/webpack/js.loader.js
+++ b/webpack/js.loader.js
@@ -99,7 +99,7 @@ module.exports = ({ isProduction }, flow) => {
             enforce: 'pre'
         },
         {
-            test: /(unsupported|browser)\.js$/,
+            test: /unsupported\.js$/,
             use: UNSUPPORTED_JS_LOADER
         },
         {

--- a/webpack/js.loader.js
+++ b/webpack/js.loader.js
@@ -40,7 +40,7 @@ module.exports = ({ isProduction }, flow) => {
                             targets: {
                                 browsers: isProduction
                                     ? [
-                                          // To define better
+                                          // TODO: Only browsers that support es6
                                           '> 0.5%, not IE 11'
                                       ]
                                     : ['last 1 chrome version', 'last 1 firefox version', 'last 1 safari version']
@@ -99,7 +99,7 @@ module.exports = ({ isProduction }, flow) => {
             enforce: 'pre'
         },
         {
-            test: /unsupported\.js$/,
+            test: /(unsupported|browser)\.js$/,
             use: UNSUPPORTED_JS_LOADER
         },
         {

--- a/webpack/optimization.js
+++ b/webpack/optimization.js
@@ -23,8 +23,7 @@ const minimizer = [
         sourceMap: true,
         terserOptions: {
             mangle: true,
-            compress: true,
-            safari10: true
+            compress: true
         }
     })
 ];


### PR DESCRIPTION
Proposal to handle unsupported browsers:

Add another entry point: `unsupported.js` that is compiled against old browsers (IE 11).

This file will reset `document.body` with an error page so that the react app can't be loaded since it targets a specific element (if the browser can run the index.js file, if it crashes it's fine since this will be displayed instead).

Thoughts?