### PR TITLE
Exlude the sprite-for-css svg

### DIFF
--- a/webpack/assets.loader.js
+++ b/webpack/assets.loader.js
@@ -1,37 +1,38 @@
 const LIMIT = 10000;
-const DESIGN_SYSTEM_SVG = /sprite-icons.svg$/;
+const DESIGN_SYSTEM_ICONS_SVG = 'sprite-icons.svg';
+const DESIGN_SYSTEM_CSS_SVG = 'sprite-for-css-only.svg';
 
 module.exports = () => [
     {
-        test: /\.(bmp|png|jpg|jpeg|gif|svg)$/,
-        loader: 'url-loader',
-        exclude: DESIGN_SYSTEM_SVG,
-        options: {
-            limit: LIMIT,
-            name: 'assets/img/[name].[hash:8].[ext]'
-        }
-    },
-    {
-        test: DESIGN_SYSTEM_SVG,
-        use: [
+        oneOf: [
             {
-                loader: 'svg-inline-loader'
-            }
-        ]
-    },
-    {
-        test: /\.(woff|woff2|eot|ttf|otf)$/,
-        use: [
+                test: new RegExp(`${DESIGN_SYSTEM_ICONS_SVG}$`),
+                use: [
+                    {
+                        loader: 'svg-inline-loader'
+                    }
+                ]
+            },
             {
-                loader: 'file-loader',
+                test: /\.(bmp|png|jpg|jpeg|gif|svg)$/,
+                loader: 'url-loader',
+                exclude: new RegExp(`${DESIGN_SYSTEM_CSS_SVG}`),
                 options: {
-                    name: 'assets/fonts/[name].[ext]'
+                    limit: LIMIT,
+                    name: 'assets/[name].[hash:8].[ext]'
                 }
+            },
+            {
+                test: /\.(bmp|png|jpg|jpeg|gif|svg|woff|woff2|eot|ttf|otf)$/,
+                use: [
+                    {
+                        loader: 'file-loader',
+                        options: {
+                            name: 'assets/[name].[hash:8].[ext]'
+                        }
+                    }
+                ]
             }
         ]
-    },
-    {
-        test: /\.po$/,
-        use: [{ loader: 'json-loader' }, { loader: 'po-gettext-loader' }]
     }
 ];

--- a/webpack/assets.loader.js
+++ b/webpack/assets.loader.js
@@ -4,6 +4,21 @@ const DESIGN_SYSTEM_CSS_SVG = 'sprite-for-css-only.svg';
 
 module.exports = () => [
     {
+        /**
+         * oneOf allows to take the first match instead of all matches, .e.g
+         *
+         * without one of:
+         *
+         * sprite-icons.svg -> [svg-inline-loader, url-loader, file-loader]
+         * img-1.svg -> [url loader, file loader]
+         * design-system-icon.svg -> file loader
+         *
+         * with one of:
+         *
+         * sprite-icons.svg -> svg-inline-loader
+         * img-1.svg -> url loader
+         * design-system-icon.svg -> file loader
+         */
         oneOf: [
             {
                 test: new RegExp(`${DESIGN_SYSTEM_ICONS_SVG}$`),


### PR DESCRIPTION
Fix https://github.com/ProtonMail/proton-vpn-settings/issues/117

* Add oneOf loader to allow to exclude files from url-loader
* Remove deprecated .po-loader