### PR TITLE
Update babel package versions and typescript to 3.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,18 +29,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.0.tgz",
-      "integrity": "sha512-Bb1NjZCaiwTQC/ARL+MwDpgocdnwWDCaugvkGt6cxfBzQa8Whv1JybBoUEiBDKl8Ni3H3c7Fykwk7QChUsHRlg==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.2.tgz",
+      "integrity": "sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==",
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.0",
+        "@babel/generator": "^7.7.2",
         "@babel/helpers": "^7.7.0",
-        "@babel/parser": "^7.7.0",
+        "@babel/parser": "^7.7.2",
         "@babel/template": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "convert-source-map": "^1.1.0",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.7.2",
+        "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
@@ -49,6 +49,48 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.2.tgz",
+          "integrity": "sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==",
+          "requires": {
+            "@babel/types": "^7.7.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.7.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.3.tgz",
+          "integrity": "sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A=="
+        },
+        "@babel/traverse": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.2.tgz",
+          "integrity": "sha512-TM01cXib2+rgIZrGJOLaHV/iZUAxf4A0dt5auY6KNZ+cm6aschuJGqKJM3ROTt3raPUdIDk9siAufIFEleRwtw==",
+          "requires": {
+            "@babel/code-frame": "^7.5.5",
+            "@babel/generator": "^7.7.2",
+            "@babel/helper-function-name": "^7.7.0",
+            "@babel/helper-split-export-declaration": "^7.7.0",
+            "@babel/parser": "^7.7.2",
+            "@babel/types": "^7.7.2",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+          "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -125,9 +167,9 @@
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.0.tgz",
-      "integrity": "sha512-ZhagAAVGD3L6MPM9/zZi7RRteonfBFLVUz3kjsnYsMAtr9hOJCKI9BAKIMpqn3NyWicPieoX779UL+7/3BEAOA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.2.tgz",
+      "integrity": "sha512-pAil/ZixjTlrzNpjx+l/C/wJk002Wo7XbbZ8oujH/AoJ3Juv0iN/UTcPUHXKMFLqsfS0Hy6Aow8M31brUYBlQQ==",
       "requires": {
         "@babel/helper-regex": "^7.4.4",
         "regexpu-core": "^4.6.0"
@@ -360,6 +402,15 @@
         "@babel/plugin-syntax-json-strings": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.4.4.tgz",
+      "integrity": "sha512-Amph7Epui1Dh/xxUxS2+K22/MUi6+6JVTvy3P58tja3B6yKTSjwwx0/d83rF7551D6PVSSoplQb8GCwqec7HRw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
@@ -448,6 +499,14 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
       "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz",
+      "integrity": "sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -815,9 +874,9 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.0.tgz",
-      "integrity": "sha512-y3KYbcfKe+8ziRXiGhhnGrVysDBo5+aJdB+x8sanM0K41cnmK7Q5vBlQLMbOnW/HPjLG9bg7dLgYDQZZG9T09g==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.7.2.tgz",
+      "integrity": "sha512-UWhDaJRqdPUtdK1s0sKYdoRuqK0NepjZto2UZltvuCgMoMZmdjhgz5hcRokie/3aYEaSz3xvusyoayVaq4PjRg==",
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.7.0",
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -929,18 +988,18 @@
       }
     },
     "@babel/preset-typescript": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.7.0.tgz",
-      "integrity": "sha512-WZ3qvtAJy8w/i6wqq5PuDnkCUXaLUTHIlJujfGHmHxsT5veAbEdEjl3cC/3nXfyD0bzlWsIiMdUhZgrXjd9QWg==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.7.2.tgz",
+      "integrity": "sha512-1B4HthAelaLGfNRyrWqJtBEjXX1ulThCrLQ5B2VOtEAznWFIFXFJahgXImqppy66lx/Oh+cOSCQdJzZqh2Jh5g==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.7.0"
+        "@babel/plugin-transform-typescript": "^7.7.2"
       }
     },
     "@babel/runtime": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.1.tgz",
-      "integrity": "sha512-SQ0sS7KUJDvgCI2cpZG0nJygO6002oTbhgSuw4WcocsnbxLwL5Q8I3fqbJdyBAc3uFrWZiR2JomseuxSuci3SQ==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
+      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -1598,10 +1657,23 @@
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
     },
+    "@types/codemirror": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-0.0.76.tgz",
+      "integrity": "sha512-k/hpUb+Ebyn9z63qM8IbsRiW0eYHZ+pi/1e2reGzBKAZJzkjWmNTXXqLLiNv5d9ekyxkajxRBr5Hu2WZq/nokw==",
+      "requires": {
+        "@types/tern": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
     },
     "@types/events": {
       "version": "3.0.0",
@@ -1669,6 +1741,14 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
+    "@types/moment-timezone": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@types/moment-timezone/-/moment-timezone-0.5.12.tgz",
+      "integrity": "sha512-hnHH2+Efg2vExr/dSz+IX860nSiyk9Sk4pJF2EmS11lRpMcNXeB4KBW5xcgw2QPsb9amTXdsVNEe5IoJXiT0uw==",
+      "requires": {
+        "moment": ">=2.14.0"
+      }
+    },
     "@types/node": {
       "version": "12.12.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
@@ -1721,6 +1801,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
       "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ=="
+    },
+    "@types/tern": {
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.3.tgz",
+      "integrity": "sha512-imDtS4TAoTcXk0g7u4kkWqedB3E4qpjXzCpD2LU5M5NAXHzCDsypyvXSaG7mM8DKYkCRa7tFp4tS/lp/Wo7Q3w==",
+      "requires": {
+        "@types/estree": "*"
+      }
     },
     "@types/uglify-js": {
       "version": "3.0.4",
@@ -3666,6 +3754,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
@@ -4129,9 +4222,9 @@
       "integrity": "sha512-u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA=="
     },
     "core-js-compat": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.3.6.tgz",
-      "integrity": "sha512-YnwZG/+0/f7Pf6Lr3jxtVAFjtGBW9lsLYcqrxhYJai1GfvrP8DEyEpnNzj/FRQfIkOOfk1j5tTBvPBLWVVJm4A==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.1.tgz",
+      "integrity": "sha512-YdeJI26gLc0CQJ9asLE5obEgBz2I0+CIgnoTbS2T0d5IPQw/OCgCIFR527RmpduxjrB3gSEHoGOCTq9sigOyfw==",
       "requires": {
         "browserslist": "^4.7.2",
         "semver": "^6.3.0"
@@ -4889,7 +4982,7 @@
       }
     },
     "design-system": {
-      "version": "github:ProtonMail/design-system#5eb03148c1729c1e142e18a5796b228e4a61f423",
+      "version": "github:ProtonMail/design-system#ce1c3adcf270737251b47bc2b43f39dfb68be07b",
       "from": "github:ProtonMail/design-system#semver:^1.5.6"
     },
     "destroy": {
@@ -5167,36 +5260,6 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.0"
-      }
-    },
-    "emailjs-addressparser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/emailjs-addressparser/-/emailjs-addressparser-2.0.2.tgz",
-      "integrity": "sha512-E6ztFf1ePtZEwqfN3aWsvZNcpBeDqgJbVL4D32dckHkcwdhJ1bhlE4MLvHBf/IoXQmJBgkKlwGP5/5l11EE5OQ=="
-    },
-    "emailjs-base64": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/emailjs-base64/-/emailjs-base64-1.1.4.tgz",
-      "integrity": "sha512-4h0xp1jgVTnIQBHxSJWXWanNnmuc5o+k4aHEpcLXSToN8asjB5qbXAexs7+PEsUKcEyBteNYsSvXUndYT2CGGA=="
-    },
-    "emailjs-mime-codec": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/emailjs-mime-codec/-/emailjs-mime-codec-2.0.9.tgz",
-      "integrity": "sha512-7qJo4pFGcKlWh/kCeNjmcgj34YoJWY0ekZXEHYtluWg4MVBnXqGM4CRMtZQkfYwitOhUgaKN5EQktJddi/YIDQ==",
-      "requires": {
-        "emailjs-base64": "^1.1.4",
-        "ramda": "^0.26.1",
-        "text-encoding": "^0.7.0"
-      }
-    },
-    "emailjs-mime-parser": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/emailjs-mime-parser/-/emailjs-mime-parser-2.0.7.tgz",
-      "integrity": "sha512-rOrRtAzq0OVLrxbTkRLyrtoY/YQldPgIzAk6lcD3LfXR0Gw3+PzsN2rO1QENY+cIQD94vYr2t2Ri0Zxlc9aeew==",
-      "requires": {
-        "emailjs-addressparser": "^2.0.1",
-        "emailjs-mime-codec": "^2.0.8",
-        "ramda": "^0.26.1"
       }
     },
     "emoji-regex": {
@@ -6713,7 +6776,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6731,11 +6795,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6748,15 +6814,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6859,7 +6928,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6869,6 +6939,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6881,17 +6952,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6908,6 +6982,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6980,7 +7055,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6990,6 +7066,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7065,7 +7142,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7095,6 +7173,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7112,6 +7191,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7150,11 +7230,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -9335,11 +9417,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
-    },
     "keygrip": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
@@ -9506,6 +9583,11 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "libphonenumber-js-utils": {
+      "version": "8.10.5",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js-utils/-/libphonenumber-js-utils-8.10.5.tgz",
+      "integrity": "sha512-VxpwgrAGps1p5avOVQVBTCpUQwkrJZqptV2DoTimY3VXTzm0EetbT73sWVTkg8FmreVmM2qwwFl7yqymdOkFug=="
     },
     "lines-and-columns": {
       "version": "1.1.6",
@@ -11469,6 +11551,16 @@
       "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
       "dev": true
     },
+    "openpgp": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-4.6.2.tgz",
+      "integrity": "sha512-zgQmTZjKxjI2vs++5Ejs8wQbs9+YekOAulfq8YxKV7uUxcNxDE2IIh88I/RmjPOvpxCrV7kNqSBwVQMzZxTtDQ==",
+      "requires": {
+        "asn1.js": "^5.0.0",
+        "node-fetch": "^2.1.2",
+        "node-localstorage": "~1.3.0"
+      }
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -12033,28 +12125,15 @@
         "asmcrypto.js": "^2.3.2",
         "bcryptjs": "^2.4.3",
         "esm": "^3.2.4",
-        "get-random-values": "github:ProtonMail/get-random-values#c13167db248ac43cb2ec1981fcdd9a2d684e2a54"
+        "get-random-values": "github:ProtonMail/get-random-values#semver:^1.0.0"
       }
     },
     "pmcrypto": {
-      "version": "github:ProtonMail/pmcrypto#87bdd3b33d11db3374a1c498430810a1e7f9aa59",
+      "version": "github:ProtonMail/pmcrypto#b505b8cce530bef82256519032a0dbdd54595b55",
       "from": "github:ProtonMail/pmcrypto#semver:^6.0.0",
       "requires": {
-        "emailjs-mime-parser": "^2.0.5",
         "esm": "^3.0.84",
-        "openpgp": "~4.5.0"
-      },
-      "dependencies": {
-        "openpgp": {
-          "version": "4.5.5",
-          "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-4.5.5.tgz",
-          "integrity": "sha512-naG9hi3EIBXYtl8FplXbfYKQCmO7JUwAFBOlejyaLi4XSmFvTtAUSxB5vTchsw7tBbejYZj01dhgqhtYRDLfRg==",
-          "requires": {
-            "asn1.js": "^5.0.0",
-            "node-fetch": "^2.1.2",
-            "node-localstorage": "~1.3.0"
-          }
-        }
+        "openpgp": "~4.6.0"
       }
     },
     "pngjs": {
@@ -13308,22 +13387,14 @@
         "ical.js": "^1.3.0",
         "lodash": "^4.17.11",
         "push.js": "^1.0.12",
-        "sieve.js": "github:ProtonMail/sieve.js#34bd49cd21f3c34a93feae9c603fb7b8276ff7af",
-        "timezone-support": "github:ProtonMail/timezone-support#73bbe37c40866b82d1a9865d1fbbe039c7495665",
+        "sieve.js": "github:ProtonMail/sieve.js#master",
+        "timezone-support": "github:ProtonMail/timezone-support#bundle",
         "ua-parser-js": "^0.7.20"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
-        },
-        "timezone-support": {
-          "version": "github:ProtonMail/timezone-support#73bbe37c40866b82d1a9865d1fbbe039c7495665",
-          "from": "github:ProtonMail/timezone-support#bundle",
-          "requires": {
-            "commander": "2.20.0"
-          }
+        "get-random-values": {
+          "version": "github:ProtonMail/get-random-values#c13167db248ac43cb2ec1981fcdd9a2d684e2a54",
+          "from": "github:ProtonMail/get-random-values#c13167db248ac43cb2ec1981fcdd9a2d684e2a54"
         }
       }
     },
@@ -13409,6 +13480,20 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
+    "qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+    },
+    "qrcode.react": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-0.9.3.tgz",
+      "integrity": "sha512-gGd30Ez7cmrKxyN2M3nueaNLk/f9J7NDRgaD5fVgxGpPLsYGWMn9UQ+XnDpv95cfszTQTdaf4QGLNMf3xU0hmw==",
+      "requires": {
+        "prop-types": "^15.6.0",
+        "qr.js": "0.0.0"
+      }
+    },
     "qrcodejs2": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/qrcodejs2/-/qrcodejs2-0.0.2.tgz",
@@ -13470,11 +13555,6 @@
         "extend": "^3.0.2",
         "fast-diff": "1.1.2"
       }
-    },
-    "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -13561,30 +13641,34 @@
       }
     },
     "react-components": {
-      "version": "github:ProtonMail/react-components#b643495fb9b006fc32b4fec28375228b8bd5daab",
+      "version": "github:ProtonMail/react-components#0343e67405e8ad051c9826369cf1016b878776bc",
       "from": "github:ProtonMail/react-components#master",
       "requires": {
+        "@types/codemirror": "0.0.76",
+        "@types/moment-timezone": "^0.5.12",
         "awesomplete": "^1.1.4",
         "card-validator": "^6.1.0",
         "codemirror": "^5.46.0",
-        "design-system": "github:ProtonMail/design-system#b952b883f80a7939c4123f2c3e98a3d15de6074e",
+        "design-system": "github:ProtonMail/design-system#master",
         "intersection-observer": "^0.5.1",
-        "keycode": "^2.2.0",
         "moment": "^2.24.0",
         "moment-timezone": "^0.5.25",
         "pikaday": "^1.8.0",
         "prop-types": "^15.7.2",
         "push.js": "^1.0.9",
+        "qrcode.react": "^0.9.3",
         "qrcodejs2": "0.0.2",
         "quill": "^1.3.6",
         "react-codemirror2": "^6.0.0",
         "react-color": "^2.17.0",
+        "react-intl-tel-input": "^7.0.1",
         "react-quill": "^1.3.3",
-        "react-sortable-hoc": "^1.9.1"
+        "react-sortable-hoc": "^1.9.1",
+        "tinycolor2": "^1.4.1"
       },
       "dependencies": {
         "design-system": {
-          "version": "github:ProtonMail/design-system#b952b883f80a7939c4123f2c3e98a3d15de6074e",
+          "version": "github:ProtonMail/design-system#cc7ed77a200ea5d67dedc8330a3fc09993efb233",
           "from": "github:ProtonMail/design-system#master"
         }
       }
@@ -13638,6 +13722,18 @@
         }
       }
     },
+    "react-intl-tel-input": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-intl-tel-input/-/react-intl-tel-input-7.1.0.tgz",
+      "integrity": "sha512-V2n94vevhluTZW+TtyH0vERJqKj16uXjDe1kXv7HyfalDZuVtxZ13TsSGltXuaVYQ1gF/uwr2YNhKiUhQnyxuA==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "libphonenumber-js-utils": "^8.10.2",
+        "prop-types": "^15.6.1",
+        "react-style-proptype": "^3.0.0",
+        "underscore.deferred": "^0.4.0"
+      }
+    },
     "react-is": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.11.0.tgz",
@@ -13670,6 +13766,14 @@
         "@babel/runtime": "^7.2.0",
         "invariant": "^2.2.4",
         "prop-types": "^15.5.7"
+      }
+    },
+    "react-style-proptype": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.2.2.tgz",
+      "integrity": "sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==",
+      "requires": {
+        "prop-types": "^15.5.4"
       }
     },
     "reactcss": {
@@ -14737,7 +14841,7 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "sieve.js": {
-      "version": "github:ProtonMail/sieve.js#34bd49cd21f3c34a93feae9c603fb7b8276ff7af",
+      "version": "github:ProtonMail/sieve.js#4c29e102bbada389034b93d08e794149d887f17c",
       "from": "github:ProtonMail/sieve.js#master"
     },
     "signal-exit": {
@@ -15775,11 +15879,6 @@
         "require-main-filename": "^2.0.0"
       }
     },
-    "text-encoding": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -15815,6 +15914,20 @@
       "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "timezone-support": {
+      "version": "github:ProtonMail/timezone-support#73bbe37c40866b82d1a9865d1fbbe039c7495665",
+      "from": "github:ProtonMail/timezone-support#bundle",
+      "requires": {
+        "commander": "2.20.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        }
       }
     },
     "timm": {
@@ -16033,6 +16146,15 @@
         "yargs": "^10.1.2"
       },
       "dependencies": {
+        "@babel/preset-typescript": {
+          "version": "7.7.0",
+          "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.7.0.tgz",
+          "integrity": "sha512-WZ3qvtAJy8w/i6wqq5PuDnkCUXaLUTHIlJujfGHmHxsT5veAbEdEjl3cC/3nXfyD0bzlWsIiMdUhZgrXjd9QWg==",
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-transform-typescript": "^7.7.0"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -16324,6 +16446,11 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "underscore.deferred": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/underscore.deferred/-/underscore.deferred-0.4.0.tgz",
+      "integrity": "sha1-J1PeYzuf99tgGi8/oq+Ss90pDmw="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -12,17 +12,19 @@
     "node": ">= 10.15.0"
   },
   "dependencies": {
-    "@babel/cli": "^7.6.2",
-    "@babel/core": "^7.6.2",
-    "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/cli": "^7.7.0",
+    "@babel/core": "^7.7.2",
+    "@babel/plugin-proposal-class-properties": "^7.7.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
-    "@babel/plugin-transform-regenerator": "^7.4.5",
+    "@babel/plugin-transform-regenerator": "^7.7.0",
     "@babel/plugin-transform-runtime": "^7.6.2",
-    "@babel/preset-env": "^7.6.2",
-    "@babel/preset-react": "^7.0.0",
-    "@babel/preset-typescript": "^7.3.3",
-    "@babel/runtime": "^7.6.2",
+    "@babel/preset-env": "^7.7.1",
+    "@babel/preset-react": "^7.7.0",
+    "@babel/preset-typescript": "^7.7.2",
+    "@babel/runtime": "^7.7.2",
     "@hot-loader/react-dom": "^16.9.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
@@ -103,7 +105,7 @@
     "husky": "^3.0.7",
     "lint-staged": "^9.4.1",
     "prettier": "^1.18.2",
-    "typescript": "^3.6.3"
+    "typescript": "^3.7.2"
   },
   "scripts": {
     "lint": "eslint $(find cli bin -type f) --quiet --cache",

--- a/webpack/js.loader.js
+++ b/webpack/js.loader.js
@@ -63,6 +63,8 @@ module.exports = ({ isProduction }, flow) => {
                 plugins: [
                     '@babel/plugin-syntax-dynamic-import',
                     '@babel/plugin-proposal-object-rest-spread',
+                    '@babel/plugin-proposal-nullish-coalescing-operator',
+                    '@babel/plugin-proposal-optional-chaining',
                     ['@babel/plugin-proposal-class-properties', { loose: true }],
                     require('babel-plugin-lodash'),
                     '@babel/plugin-transform-runtime',


### PR DESCRIPTION
Typescript 3.7 added official support for some nice features: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html

`some?.optional?.stuff`
`some.iMightBeNull?.()`

`iAmNull ?? 'default'`

Needed to add some babel packages to support this stuff, as in our setup typescript compiler only typechecks the code.