### PR TITLE
Add feature flags argument

### DIFF
--- a/bin/protonPack
+++ b/bin/protonPack
@@ -14,13 +14,21 @@ const { getPort, getPublicPath, findPort } = require('../webpack/helpers/source'
 
 const is = (command) => argv._.includes(command);
 
-const getAppMode = () => {
-    // Many flags appMode creates an array, take the last one.
-    if (Array.isArray(argv.appMode)) {
-        const { length, [length - 1]: last, first } = argv.appMode;
-        return last || first || 'bundle';
+const getSingleArgument = (argument) => {
+    // Many flags creates an array, take the last one.
+    if (Array.isArray(argument)) {
+        const { length, [length - 1]: last, first } = argument;
+        return last || first;
     }
-    return argv.appMode || 'bundle';
+    return argument;
+};
+
+const getFeatureFlags = () => {
+    return getSingleArgument(argv.featureFlags) || '';
+};
+
+const getAppMode = () => {
+    return getSingleArgument(argv.appMode) || 'bundle';
 };
 
 const {
@@ -29,7 +37,9 @@ const {
     apiUrl,
     json: jsonConfig
 } = configAppBuilder(argv);
+
 const APP_MODE = getAppMode();
+const FEATURE_FLAGS = getFeatureFlags();
 
 async function main() {
 
@@ -52,6 +62,7 @@ async function main() {
         const CONFIG = configBuilder({
             publicPath,
             appMode: APP_MODE,
+            featureFlags: FEATURE_FLAGS,
             ...is('extract-i18n') && { flow: 'i18n' }
         });
         return compile(CONFIG);
@@ -70,7 +81,7 @@ async function main() {
             ➙ API: ${chalk.yellow(apiUrl)}
             \n
         `);
-        const CONFIG = configBuilder({ port, publicPath, appMode: APP_MODE });
+        const CONFIG = configBuilder({ port, publicPath, appMode: APP_MODE, featureFlags: FEATURE_FLAGS });
 
         const run = server(CONFIG);
         run.listen(port);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,11 +11,12 @@ const { outputPath } = require('./webpack/paths');
 const { excludeNodeModulesExcept, excludeFiles, createRegex } = require('./webpack/helpers/regex');
 const { BABEL_EXCLUDE_FILES, BABEL_INCLUDE_NODE_MODULES } = require('./webpack/constants');
 
-function main({ port, publicPath, flow, appMode }) {
+function main({ port, publicPath, flow, appMode, featureFlags }) {
     const conf = {
         isProduction: process.env.NODE_ENV === 'production',
         publicPath: publicPath || '/',
-        appMode
+        appMode,
+        featureFlags
     };
 
     const { isProduction } = conf;

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -62,7 +62,7 @@ const PRODUCTION_PLUGINS = [
     })
 ];
 
-module.exports = ({ isProduction, publicPath, appMode }) => {
+module.exports = ({ isProduction, publicPath, appMode, featureFlags }) => {
     const { main, worker, elliptic, compat, definition } = transformOpenpgpFiles(
         OPENPGP_FILES,
         publicPath,
@@ -104,7 +104,8 @@ module.exports = ({ isProduction, publicPath, appMode }) => {
 
         new webpack.DefinePlugin({
             PM_OPENPGP: JSON.stringify(definition),
-            PL_IS_STANDALONE: appMode === 'standalone'
+            PL_IS_STANDALONE: appMode === 'standalone',
+            FEATURE_FLAGS: JSON.stringify(featureFlags)
         }),
 
         new ScriptExtHtmlWebpackPlugin({


### PR DESCRIPTION
Allows it to be used like:

```
npm run start -- --api=blue --featureFlags=calendar,darkmode,drive

proton-pack compile --appMode=standalone --featureFlags=calendar
```

and then a global variable `FEATURE_FLAGS` (which is a string) can be used in the code like this:

https://github.com/ProtonMail/react-components/pull/411/commits/6595aa809df99b14de1bf7b2ee5f076849a78cb7#diff-0dd6a0cde77b98062347866b92890e7fR14