### PR TITLE
Fix new openpgp version worker loading

### DIFF
--- a/webpack/helpers/openpgp.js
+++ b/webpack/helpers/openpgp.js
@@ -9,8 +9,7 @@ const getDefineObject = (publicPath, { filepath, integrity }) => {
     };
 };
 
-const transformWorkerContents = (path, contents) =>
-    contents.replace('self.window=self,importScripts("openpgp.min.js");', '');
+const transformWorkerContents = (path, contents) => contents.replace('importcripts("openpgp.min.js");', '');
 
 const transformCompatPath = ({ basename, ext, hash }) => [basename, 'compat', hash, ext].join('.');
 


### PR DESCRIPTION
The new version removed `self.window=self,` from the first line.