### PR TITLE
Use a different favicon in the development environment

### DIFF
--- a/bin/protonPack
+++ b/bin/protonPack
@@ -5,12 +5,16 @@ const chalk = require('chalk');
 const dedent = require('dedent');
 const argv = require('minimist')(process.argv.slice(2));
 const localIp = require('my-local-ip');
+const fsPromises = require('fs').promises;
 
 const configBuilder = require('../cli/config');
 const configAppBuilder = require('../cli/configApp');
 const { json, debug, success } = require('../cli/helpers/log');
 const { script } = require('../cli/helpers/cli');
-const { getPort, getPublicPath, findPort } = require('../webpack/helpers/source');
+const { getPort, getPublicPath, getSource, findPort } = require('../webpack/helpers/source');
+const getDevIcon = require('../cli/helpers/devIcon');
+
+const { logo: logoPath } = require(getSource('src/assets/logoConfig.js'));
 
 const is = (command) => argv._.includes(command);
 
@@ -73,6 +77,10 @@ async function main() {
         const port = await findPort(getPort(argv));
         const publicPath = getPublicPath(argv);
 
+        const devIconData = await getDevIcon(logoPath);
+        const devIconPath = getSource('.tmp.logo.png');
+        await fsPromises.writeFile(devIconPath, devIconData);
+
         const log = (ip = 'localhost') => chalk.yellow(`http://${ip}:${port}${publicPath}`);
         console.log(dedent`
             ➙ Dev server: ${log()}
@@ -80,7 +88,13 @@ async function main() {
             ➙ API: ${chalk.yellow(apiUrl)}
             \n
         `);
-        const CONFIG = configBuilder({ port, publicPath, appMode: APP_MODE, featureFlags: FEATURE_FLAGS });
+        const CONFIG = configBuilder({
+            port,
+            publicPath,
+            appMode: APP_MODE,
+            featureFlags: FEATURE_FLAGS,
+            favicon: devIconPath
+        });
 
         const run = server(CONFIG);
         run.listen(port);

--- a/cli/helpers/devIcon.js
+++ b/cli/helpers/devIcon.js
@@ -1,0 +1,30 @@
+const sharp = require('sharp');
+
+const DEV_TEXT = Buffer.from(`
+<svg height="200" width="200">
+  <rect y="0" width="130" height="55" fill="red" rx="15" />
+  <text x="2" y="50" font-family="Arial, Helvetica, sans-serif" font-size="60px" fill="white">DEV</text>
+</svg>
+`);
+
+const getDevIcon = (logoPath) => {
+    return (
+        sharp(logoPath, { density: 900 })
+            .resize(200, 200)
+            /*
+        .modulate({
+            brightness: 2
+        })
+        */
+            .composite([
+                {
+                    input: DEV_TEXT,
+                    blend: 'over'
+                }
+            ])
+            .png()
+            .toBuffer()
+    );
+};
+
+module.exports = getDevIcon;

--- a/cli/helpers/devIcon.js
+++ b/cli/helpers/devIcon.js
@@ -8,23 +8,16 @@ const DEV_TEXT = Buffer.from(`
 `);
 
 const getDevIcon = (logoPath) => {
-    return (
-        sharp(logoPath, { density: 900 })
-            .resize(200, 200)
-            /*
-        .modulate({
-            brightness: 2
-        })
-        */
-            .composite([
-                {
-                    input: DEV_TEXT,
-                    blend: 'over'
-                }
-            ])
-            .png()
-            .toBuffer()
-    );
+    return sharp(logoPath, { density: 900 })
+        .resize(200, 200)
+        .composite([
+            {
+                input: DEV_TEXT,
+                blend: 'over'
+            }
+        ])
+        .png()
+        .toBuffer();
 };
 
 module.exports = getDevIcon;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,12 +11,13 @@ const { outputPath } = require('./webpack/paths');
 const { excludeNodeModulesExcept, excludeFiles, createRegex } = require('./webpack/helpers/regex');
 const { BABEL_EXCLUDE_FILES, BABEL_INCLUDE_NODE_MODULES } = require('./webpack/constants');
 
-function main({ port, publicPath, flow, appMode, featureFlags }) {
+function main({ port, publicPath, flow, appMode, featureFlags, favicon }) {
     const conf = {
         isProduction: process.env.NODE_ENV === 'production',
         publicPath: publicPath || '/',
         appMode,
-        featureFlags
+        featureFlags,
+        favicon
     };
 
     const { isProduction } = conf;

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -62,7 +62,7 @@ const PRODUCTION_PLUGINS = [
     })
 ];
 
-module.exports = ({ isProduction, publicPath, appMode, featureFlags }) => {
+module.exports = ({ isProduction, publicPath, appMode, featureFlags, favicon = getSource(logo) }) => {
     const { main, worker, elliptic, compat, definition } = transformOpenpgpFiles(
         OPENPGP_FILES,
         publicPath,
@@ -93,7 +93,7 @@ module.exports = ({ isProduction, publicPath, appMode, featureFlags }) => {
         }),
 
         new WebappWebpackPlugin({
-            logo: getSource(logo),
+            logo: favicon,
             ...logoConfig
         }),
 


### PR DESCRIPTION
Before running the dev server, parse the logo of the application and composite a DEV text to more easily see that it's the development environment.

It generates a file `.tmp.logo.png` in the project folder

**Example:**
<img width="242" alt="Screenshot 2020-02-21 at 20 04 39" src="https://user-images.githubusercontent.com/352607/75064406-344f1d00-54e7-11ea-860f-872de6a3e931.png">
