### PR TITLE
Upgrade sharp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6402,6 +6402,42 @@
         "to-ico": "^1.1.5",
         "vinyl": "^2.2.0",
         "xml2js": "^0.4.22"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "sharp": {
+          "version": "0.23.4",
+          "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.4.tgz",
+          "integrity": "sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==",
+          "requires": {
+            "color": "^3.1.2",
+            "detect-libc": "^1.0.3",
+            "nan": "^2.14.0",
+            "npmlog": "^4.1.2",
+            "prebuild-install": "^5.3.3",
+            "semver": "^6.3.0",
+            "simple-get": "^3.1.0",
+            "tar": "^5.0.5",
+            "tunnel-agent": "^0.6.0"
+          }
+        },
+        "tar": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
+          "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
+          "requires": {
+            "chownr": "^1.1.3",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.0",
+            "mkdirp": "^0.5.0",
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "favicons-webpack-plugin": {
@@ -14867,25 +14903,25 @@
       "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "sharp": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.4.tgz",
-      "integrity": "sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.24.1.tgz",
+      "integrity": "sha512-1Lph6o7D6bU8WrcbG/kT7cVzi2UBi2xrrBfS/WUaD+ZcGd4MZ7+LbtFoGwbMVJH95d5aziBGyExYF4Urm2pjOQ==",
       "requires": {
         "color": "^3.1.2",
         "detect-libc": "^1.0.3",
         "nan": "^2.14.0",
         "npmlog": "^4.1.2",
         "prebuild-install": "^5.3.3",
-        "semver": "^6.3.0",
+        "semver": "^7.1.3",
         "simple-get": "^3.1.0",
-        "tar": "^5.0.5",
+        "tar": "^6.0.1",
         "tunnel-agent": "^0.6.0"
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
         }
       }
     },
@@ -15785,16 +15821,23 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.5.tgz",
-      "integrity": "sha512-MNIgJddrV2TkuwChwcSNds/5E9VijOiw7kAc1y5hTNJoLDSuIyid2QtLYiCYNnICebpuvjhPQZsXwUL0O3l7OQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.0.1.tgz",
+      "integrity": "sha512-bKhKrrz2FJJj5s7wynxy/fyxpE0CmCjmOQ1KV4KkgXFWOgoIT/NbTMnB1n+LFNrNk0SSBVGGxcK5AGsyC+pW5Q==",
       "requires": {
         "chownr": "^1.1.3",
         "fs-minipass": "^2.0.0",
         "minipass": "^3.0.0",
         "minizlib": "^2.1.0",
-        "mkdirp": "^0.5.0",
+        "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+          "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+        }
       }
     },
     "tar-fs": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "sass-loader": "^8.0.2",
     "script-ext-html-webpack-plugin": "^2.1.3",
     "script-loader": "^0.7.2",
-    "sharp": "^0.23.4",
+    "sharp": "^0.24.1",
     "source-map-loader": "^0.2.4",
     "string-replace-loader": "^2.2.0",
     "strip-ansi": "^6.0.0",


### PR DESCRIPTION
As the fix for Node.JS 13 is available for months inside sharp, leþ's update it.
It seems like the build is ok with it.

### Node LTS
```
[proton-bundler] ✔ Build CI app to the directory: dist (03:55)                                         
```

### Node 13
```sh
[proton-bundler] ✔ Build CI app to the directory: dist (03:46)                              
``` 