### PR TITLE
fix(docs): change language identifier to jsonc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ npm i -D github:ProtonMail/proton-pack.git#semver:^1.0.0
 
 As for the WebClient you need to have `appConfig.json` (_previously_ `env.json`)<br>
 A new key exists inside this file now, to add more config
-```json
+```jsonc
 {
     "appConfig": {
         "clientId": "WebMail", // use to identify the application by the API


### PR DESCRIPTION
## Description

This PR changes the language identifier of the JSON code block in the README file to `jsonc` to improve the readability.

Ref: https://github.com/github/linguist/issues/4153

## Result

Before 

<img width="957" alt="Screen Shot 2020-04-15 at 7 37 55 AM" src="https://user-images.githubusercontent.com/25715018/79286878-2f598900-7eec-11ea-8e8f-a92383d0decd.png">

After

<img width="962" alt="Screen Shot 2020-04-15 at 7 37 38 AM" src="https://user-images.githubusercontent.com/25715018/79286885-36809700-7eec-11ea-92fa-e9e438209f68.png">
