### PR TITLE
Disable react-refresh overlay

### DIFF
--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -76,7 +76,9 @@ module.exports = ({ isProduction, publicPath, appMode, featureFlags, writeSRI })
             : [
                   new webpack.HotModuleReplacementPlugin(),
                   new webpack.NamedModulesPlugin(),
-                  new ReactRefreshWebpackPlugin()
+                  new ReactRefreshWebpackPlugin({
+                      overlay: false
+                  })
               ]),
 
         new WriteWebpackPlugin(


### PR DESCRIPTION
Not possible to disable the overlay for only unhandled promise rejections