### PR TITLE
Prepend public path when there is one

### DIFF
--- a/bin/protonPack
+++ b/bin/protonPack
@@ -51,6 +51,7 @@ async function main() {
     const APP_MODE = getAppMode();
     const FEATURE_FLAGS = getFeatureFlags();
     const WRITE_SRI = argv.sri;
+    const publicPath = getPublicPath(argv);
 
     // For any task BUT init we need to create a custom config for the app
     if (!is('init') && !is('help') && !is('print-config')) {
@@ -66,7 +67,6 @@ async function main() {
 
     if (is('compile') || is('extract-i18n')) {
         const compile = require('../cli/compile');
-        const publicPath = getPublicPath(argv);
         const CONFIG = configBuilder({
             publicPath,
             appMode: APP_MODE,
@@ -81,7 +81,6 @@ async function main() {
     if (is('dev-server')) {
         const server = require('../cli/server');
         const port = await findPort(getPort(argv));
-        const publicPath = getPublicPath(argv);
 
         const log = (ip = 'localhost') => chalk.yellow(`http://${ip}:${port}${publicPath}`);
         console.log(dedent`

--- a/cli/configApp.js
+++ b/cli/configApp.js
@@ -5,6 +5,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const { sync } = require('./helpers/cli');
 const { warn, error } = require('./helpers/log');
 const prepareSentry = require('./helpers/sentry');
+const { getPublicPath } = require('../webpack/helpers/source');
 
 const isSilent = argv._.includes('help') || argv._.includes('init') || argv._.includes('print-config');
 
@@ -151,6 +152,8 @@ function main({ api = 'dev' }) {
         dsn: SENTRY_DSN
     };
 
+    const PUBLIC_APP_PATH = getPublicPath(argv);
+
     const config = dedent`
     export const CLIENT_ID = '${json.clientId}';
     export const CLIENT_TYPE = ${ENV_CONFIG.app.clientType || 1};
@@ -161,8 +164,8 @@ function main({ api = 'dev' }) {
     export const LOCALES = ${JSON.stringify(LOCALES)};
     export const API_VERSION = '3';
     export const DATE_VERSION = '${new Date().toGMTString()}';
-    export const CHANGELOG_PATH = 'assets/changelog.tpl.html';
-    export const VERSION_PATH = 'assets/version.json';
+    export const CHANGELOG_PATH = '${PUBLIC_APP_PATH}assets/changelog.tpl.html';
+    export const VERSION_PATH = '${PUBLIC_APP_PATH}assets/version.json';
     export const COMMIT_RELEASE = '${COMMIT_RELEASE}';
     export const SENTRY_DSN = '${SENTRY_DSN}';
     `;


### PR DESCRIPTION
with --publicPath
```js
export const CHANGELOG_PATH = '/settings/assets/changelog.tpl.html';
export const VERSION_PATH = '/settings/assets/version.json';
```
Without

```js
export const CHANGELOG_PATH = '/assets/changelog.tpl.html';
export const VERSION_PATH = '/assets/version.json';
```