### PR TITLE
Use corejs 3.9 in Babel configuration

### DIFF
--- a/webpack/js.loader.js
+++ b/webpack/js.loader.js
@@ -14,7 +14,7 @@ const UNSUPPORTED_JS_LOADER = [
                     {
                         targets: { browsers: ['ie 11'] },
                         useBuiltIns: 'entry',
-                        corejs: 3
+                        corejs: 3.9
                     }
                 ]
             ],
@@ -45,7 +45,7 @@ const getBabelLoader = ({ isProduction = false, hasReactRefresh = true, isTtag =
                                 : ['last 1 chrome version', 'last 1 firefox version', 'last 1 safari version']
                         },
                         useBuiltIns: 'entry',
-                        corejs: 3,
+                        corejs: 3.9,
                         exclude: ['transform-typeof-symbol'] // Exclude transforms that make all code slower
                     }
                 ],


### PR DESCRIPTION
Core-js added Promise.allSettled in version 3.2 which we need to have for Drive.