### PR TITLE
Feat - add new file icon sprite

### DIFF
--- a/webpack/assets.loader.js
+++ b/webpack/assets.loader.js
@@ -1,5 +1,5 @@
 const LIMIT = 10000;
-const DESIGN_SYSTEM_ICONS_SVG = 'sprite-icons.svg|mime-icons.svg';
+const DESIGN_SYSTEM_ICONS_SVG = 'sprite-icons.svg|mime-icons.svg|file-icons.svg';
 const DESIGN_SYSTEM_CSS_SVG = 'sprite-for-css-only.svg';
 
 module.exports = () => [


### PR DESCRIPTION
For Drive (and probably others after :), we need to inline the upcoming sprite https://github.com/ProtonMail/design-system/blob/master/assets/img/sprite-icons/file-icons.svg 